### PR TITLE
Rescue stm python

### DIFF
--- a/Documentation/source/Matching.rst
+++ b/Documentation/source/Matching.rst
@@ -17,17 +17,19 @@ How does it work?
 
 |
 
-This step has been written in ``Python`` and in ``C++``. The ``C++`` version is 5 times quicker but the ``Python`` one is simpler to use. We will describe both ot them in the following. **We strongly advice you to use ``C++`` version for which the support will be more efficient.**
+This step has been written in ``Python`` and in ``C++``. The ``C++`` version is
+approximately 10% faster but the ``Python`` one is simpler to use. We will
+describe both ot them in the following.
 
-Python way (Depreciated)
-------------------------
+Python way
+----------
 
 The function which do the matching is ``stm.py``. It takes 11 arguments:
 
 - **filename**                 : name of the file containing rays,
 - **minframes**                : number of the first frame,
 - **maxframes**                : number of the last frame,
-- **cam_match**                 : minimum number of crossing rays to get a match,
+- **cam_match**                : minimum number of crossing rays to get a match,
 - **maxdistance**              : max distance allowed for a match,
 - **nx,ny,nz**                 : number of voxels in each direction,
 - **maxmatchesperray**         : number of matches/ray,
@@ -63,10 +65,28 @@ The function creates in the rays folder a file called ``matched_cam{cam_match}_{
 - **other** which is a nmatches x ? matrix [NumberofRaysUsedInMatch, cam0ID,ray0ID,cam1ID,rays1ID,...]
 - **params** whose *params.nframes* gives number of frames and *params.nmatches* provides number of matches.
 
+Installation
+~~~~~~~~~~~~
+
+This package requires Python 3.8. The code is accelerated with `Transonic
+<https://transonic.readthedocs.io>`_ and `Pythran
+<https://pythran.readthedocs.io>`_. Some functions are transpiled to C++ to be
+very efficient.
+
+The Python dependencies can be installed with::
+
+  pip install numpy transonic pythran
+
+You first need to compile the code with the command ``make``. Note that you
+need a quite recent C++ compiler (more details `here
+<https://fluidsim.readthedocs.io/en/latest/install.html#about-using-pythran-to-compile-functions>`_).
+
 C++ way
 --------
 
-The ``C++`` script is al least 50 times faster than the ``Python`` one. This script should be use when you try to track more than 500-1000 particles because then the ``Python`` script is to long. If you track several thousands of particles, you should take a look at the PSMN part where we show how to parallelise computations.
+The ``C++`` script is approximately 10% faster than the ``Python`` one. If you
+track several thousands of particles, you should take a look at the PSMN part
+where we show how to parallelise computations.
 
 .. warning:: Compilation of C++ code
 
@@ -105,8 +125,6 @@ By defaut, it saves results in a h5 file.
 
 
 with the same meaning than for Python way. The ``C++`` language requires to compile scripts before running them. That is done automatically during the library installation. The compiled version of ``STM.cpp`` is ``STM``.
-
-
 
 How to compile ``STM.cpp`` file ?
     We did a ``makefile`` which simplifies everything for you. Before using the 4D-PTV toolbox for the first time, just do:

--- a/Documentation/source/Tutorial.rst
+++ b/Documentation/source/Tutorial.rst
@@ -3,7 +3,6 @@ Tutorial
 
 This tutorial will show you how to use this library to do 4D PTV. 4D PTV means Particle Tracking Velocimetry and allows you to tracks particles in space and time in your experiment. For that you need at least 2 cameras but as we will see later, the more camera you have, the better your traking will be. The cameras need to be placed arround your experimental setup in order to see the volume you want to observe from different points of view. If you have more than 2 cameras it is better to place them not in the same plane, but preferently in a pyramidal scheme directed toward the observed volume.
 
-
 Required Material
 ====================
 - 2 (or more) synchronized cameras,
@@ -11,19 +10,23 @@ Required Material
 - a calibration mire: a 2D rigid sheet composed of black/white regularly spaced dots.
 - your data need to respect the following folder architecture
 
-
 .. image:: Figures/FolderLagrangien.png
     :width: 300
-    
+
 Required Software
 ====================
 - ``Matlab``
 - ``Python``
-- ``C++`` librairy
+- ``C++`` library
 
-All scripts are written in ``Matlab`` except one which is written in ``Python`` or in ``C++`` to be faster.
+All scripts are written in ``Matlab`` except for one task (Matching), for which
+there are 2 versions written in ``Python`` and in ``C++``.
 
+This tutorial is made of three parts: first we will describe the calibration
+process which is crucial, then the treatment process to obtain particles
+trajectories, and finally the post-treatment tools we provide in this library.
 
-This tutorial is made of three parts: first we will describe the calibration process which is crucial, then the treatment process to obtain particles trajectories, and finally the post-treatment tools we provide in this library.
-
-In this library, we also provide some test data used in this tutorial to show you how does this library work. These test data were obtained using 3 cameras in a Rayleigh-Bénard setup. We provide 100 frames which corresponds to 0.66s of acquisition.
+In this library, we also provide some test data used in this tutorial to show
+you how does this library work. These test data were obtained using 3 cameras
+in a Rayleigh-Bénard setup. We provide 100 frames which corresponds to 0.66s of
+acquisition.

--- a/Matching/STMPython/stm.py
+++ b/Matching/STMPython/stm.py
@@ -37,9 +37,8 @@ Command to launch the same computation (?) with Python::
   STM_PYTHON_USE_UNOPTIMIZED=1 python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
   python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
 
-The old result is: "6754 matched found (out of 135271 candidates)".
-
-Now, it gives "6840 matched found (out of 229311 candidates)".
+With both versions, the same number of matches are found out of the same number
+of candidates: "6754 matched found (out of 135271 candidates)".
 
 Command to launch the C++ code::
 

--- a/Matching/STMPython/stm.py
+++ b/Matching/STMPython/stm.py
@@ -46,7 +46,6 @@ Command to launch the C++ code::
   ../STMCpp/STM -i $PATH_INPUT_DATA -f 1 -c 2 -d 0.2 -m 2 -x 400 -y 400 -z 250 -b -140 140 -150 150 5 170 --hdf5
 
 The result of the C++ code is 7466 matched found (out of 135271 candidates)
-
 """
 
 if not USE_UNOPTIMIZED:

--- a/Matching/STMPython/stm.py
+++ b/Matching/STMPython/stm.py
@@ -32,14 +32,20 @@ To be compared to the perf of the C++ code: 8.45 s!
 
 - The unoptimized Python code is 21.2 time slower than the optimized C++ one.
 
+Command to launch the same computation (?) with Python::
+
+  STM_PYTHON_USE_UNOPTIMIZED=1 python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
+  python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
+
+The old result is: "6754 matched found (out of 135271 candidates)".
+
+Now, it gives "6840 matched found (out of 229311 candidates)".
+
 Command to launch the C++ code::
 
   ../STMCpp/STM -i $PATH_INPUT_DATA -f 1 -c 2 -d 0.2 -m 2 -x 400 -y 400 -z 250 -b -140 140 -150 150 5 170 --hdf5
 
-Command to launch the same computation (?) with Python::
-
-  python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
-  STM_PYTHON_USE_UNOPTIMIZED=1 python stm.py $PATH_INPUT_DATA 1 2 2 0.2 400 400 250 2
+The result of the C++ code is 7466 matched found (out of 135271 candidates)
 
 """
 

--- a/Matching/STMPython/stm_util.py
+++ b/Matching/STMPython/stm_util.py
@@ -12,8 +12,6 @@ import datetime
 import sys
 from time import perf_counter
 
-from pprint import pprint
-
 import numpy as np
 
 from transonic import boost, Tuple, List, Array
@@ -411,7 +409,9 @@ def compute_cells_traversed_by_rays(valid_rays, bounds, neighbours):
                 (
                     directional_voxel_traversal(position, vector_ray, bounds),
                     directional_voxel_traversal(
-                        position, tuple(map(lambda x: -x, vector_ray)), bounds,
+                        position,
+                        tuple(map(lambda x: -x, vector_ray)),
+                        bounds,
                     ),
                 )
             )
@@ -441,18 +441,8 @@ def compute_cells_traversed_by_rays(valid_rays, bounds, neighbours):
     return np.vstack(cells_all), np.vstack(cam_ray_ids_all)
 
 
-def uniquify_candidates(candidates,):
+def uniquify_candidates(candidates):
     return list(set(candidates))
-
-
-def kernel_make_candidates(traversed):
-    # All combinations between all cameras
-    candidates = list(
-        map(lambda x: [tuple(tup) for tup in itertools.product(*x)], traversed)
-    )
-    # Flatten a list of lists to a single list
-    candidates = joinlists(candidates)
-    return candidates
 
 
 def make_candidates(traversed, candidates0, raydb, log_print):
@@ -460,28 +450,24 @@ def make_candidates(traversed, candidates0, raydb, log_print):
     t_start = perf_counter()
     print("PA: make_candidates")
 
-    candidates = kernel_make_candidates(traversed)
+    # All combinations between all cameras
+    candidates = list(
+        map(
+            lambda x: [tuple(sorted(tup)) for tup in itertools.product(*x)],
+            traversed,
+        )
+    )
+    # Flatten a list of lists to a single list
+    candidates = joinlists(candidates)
 
-    print("\ncandidates (after joinlists):")
-    pprint(candidates[:4])
-
-    print("\ncandidates0:")
-    pprint(candidates0[:4])
+    candidates.extend(candidates0)
 
     log_print("Flattened list of candidates:", len(candidates))
     # Delete duplicates, flattened list as tag
     candidates = uniquify_candidates(candidates)
 
-    print("\ncandidates (after uniquify):")
-    pprint(candidates[:4])
-
-    candidates.extend(candidates0)
-
     log_print("Duplicate candidates removed:", len(candidates))
     candidates = sorted(candidates)
-
-    print("\ncandidates (after sorted):")
-    pprint(candidates[:4])
 
     # log_print("Computing match position and quality of candidates...")
     newcandidates = []
@@ -664,11 +650,6 @@ def space_traversal_matching(
     )
 
     log_print("Sorted and grouped by cell index. # of groups:", len(traversed))
-
-    print("\nPA: traversed after grouped by:")
-    pprint(traversed[:4])
-
-    log_print("Pruned based on number of cameras:", len(traversed))
 
     candidates = make_candidates(traversed, candidates0, raydb, log_print)
 

--- a/Matching/STMPython/stm_util.py
+++ b/Matching/STMPython/stm_util.py
@@ -355,8 +355,6 @@ def prepare_ray(point, v, bounds):
 
 def make_ray_database(rays, boundingbox, log_print):
 
-    print("PA: make_ray_database")
-
     # Store a dictionary of (cameraid, ray_id): [pos, direction]
     raydb = {}
     valid_rays = []  # Store the transformed rays
@@ -397,7 +395,6 @@ def make_ray_database(rays, boundingbox, log_print):
 
 def compute_cells_traversed_by_rays(valid_rays, bounds, neighbours):
 
-    print("PA: compute_cells_traversed_by_rays")
     t_start = perf_counter()
 
     cells_all = []
@@ -434,7 +431,7 @@ def compute_cells_traversed_by_rays(valid_rays, bounds, neighbours):
         cam_ray_ids_all.append(cam_ray_ids)
 
     print(
-        "PA: compute_cells_traversed_by_rays done in "
+        "compute_cells_traversed_by_rays done in "
         f"{perf_counter() - t_start:.2f} s"
     )
 
@@ -448,7 +445,6 @@ def uniquify_candidates(candidates):
 def make_candidates(traversed, candidates0, raydb, log_print):
 
     t_start = perf_counter()
-    print("PA: make_candidates")
 
     # All combinations between all cameras
     candidates = list(
@@ -507,14 +503,14 @@ def make_candidates(traversed, candidates0, raydb, log_print):
     # for i in range(1,len(candidates),100):
     #    print(i,candidates[i])
 
-    print(f"PA: make_candidates done in {perf_counter() - t_start:.2f} s")
+    print(f"make_candidates done in {perf_counter() - t_start:.2f} s")
 
     return candidates
 
 
 def make_approved_matches(candidates, maxdistance, max_matches_per_ray):
     t_start = perf_counter()
-    print(f"PA: make_approved_matches", end="")
+    print(f"make_approved_matches", end="")
     approved_matches = []  # Store approved candidates
     matchcounter = Counter()  # Keep track of how many they are matched
     for cand in candidates:

--- a/Matching/STMPython/stm_util.py
+++ b/Matching/STMPython/stm_util.py
@@ -86,7 +86,8 @@ def special_division(a, b):
         return a / b
 
 
-def find_index_bin(boundaries, value):
+@boost
+def find_index_bin(boundaries: "float[:]", value: "float"):
     """
     Gives index in which 'bin' the value value will fall with boundaries 'boundaries', -1
     = outside
@@ -110,7 +111,7 @@ def find_index_bin(boundaries, value):
         while mx - mn > 1:
             # print('min',mn,'max',mx)
             # Banker's rounding but does not matter, still O(Log(N)) scaling
-            trial = round((mn + mx) / 2)
+            trial = int(round((mn + mx) / 2))
             if value > boundaries[trial]:
                 mn = trial
             else:

--- a/Matching/STMPython/util_groupby.py
+++ b/Matching/STMPython/util_groupby.py
@@ -1,4 +1,3 @@
-# from pprint import pprint
 import itertools
 
 import numpy as np
@@ -86,25 +85,41 @@ def kernel_make_groups_by_cell_cam(
                 nb_cameras = len(set(cam_ids))
                 if nb_cameras >= cam_match:
                     if nb_elems == 2:
-                        # we can already compute candidates
-                        candidates.append((tuple(group[0]), tuple(group[1])))
+                        # we can already compute the candidate
+                        tup0 = tuple(group[0])
+                        tup1 = tuple(group[1])
+                        # we'd like to have (not supported by Pythran)
+                        # if tup1 > tup0:
+                        #     cand = (tup0, tup1)
+                        # else:
+                        #     cand = (tup1, tup0)
+                        # it could also be written as (not supported by Pythran)
+                        # cand = sorted((tup0, tup1))
+                        # Pythran supports
+                        # (buggy, then we need the list comp. at the end)
+                        cand = (tup0, tup1)
+                        candidates.append(cand)
                     else:
                         groups_cam = group_by_cam(group)
                         assert len(groups_cam) == nb_cameras
                         if nb_cameras == 2:
+                            # we can already compute candidates
                             candidates.extend(
                                 [
-                                    tuple(tup)
+                                    # not supported by Pythran
+                                    # tuple(sorted(tup))
+                                    tup
                                     for tup in itertools.product(
                                         groups_cam[0], groups_cam[1]
                                     )
                                 ]
                             )
-                        # no supported by Pythran?
+                        # it would be good for performance to do the same
+                        # with 3 cameras (no supported by Pythran?)
                         # elif nb_cameras == 3:
                         #     candidates.extend(
                         #         [
-                        #             tuple(tup)
+                        #             tup
                         #             for tup in itertools.product(
                         #                 groups_cam[0],
                         #                 groups_cam[1],
@@ -116,6 +131,8 @@ def kernel_make_groups_by_cell_cam(
                             groups.append(groups_cam)
             start_group = stop_group
 
+    # needed because we can't add sorted tuples above (Pythran limitation)
+    candidates = [tuple(sorted(cand)) for cand in candidates]
     candidates = list(set(candidates))
     return groups, candidates
 

--- a/Matching/STMPython/util_groupby.py
+++ b/Matching/STMPython/util_groupby.py
@@ -159,14 +159,11 @@ def make_groups_by_cell_cam(cells_all, cam_ray_ids, cam_match: int):
 
     """
     t_start = perf_counter()
-    print("PA: make_groups_by_cell_cam")
-
     indices, diffs = special_argsort(cells_all)
     del cells_all
     cam_ray_ids_sorted = cam_ray_ids[indices, :]
     groups, candidates = kernel_make_groups_by_cell_cam(
         cam_ray_ids_sorted, diffs, cam_match
     )
-    print(f"PA # of unique group: {len(groups)}")
-    print(f"PA: make_groups_by_cell_cam done in {perf_counter() - t_start:.2f} s")
+    print(f"make_groups_by_cell_cam done in {perf_counter() - t_start:.2f} s")
     return groups, candidates


### PR DESCRIPTION
This completes my last PR. Most importantly, I thing the code is now correct, at least

```
With both Python versions, the same number of matches are found out of the same number
of candidates: "6754 matched found (out of 135271 candidates)".
```

However, I didn't use the Matlab function to check that. @jsalort you could try the new Python version and check whether the results seem correct.

In terms of performance, the Python version is now only 10% slower than the C++ version (compared to 20 times slower before these PR). Some improvements of Pythran could help in the near future.

There are still some very simple tasks to be done on this code, in particular using `argparse` and `h5py` (or `h5netcdf`) to save data in a better format.